### PR TITLE
update metadata - EF API docs

### DIFF
--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -55,6 +55,7 @@
       "extendBreadcrumb": true,
       "searchScope": ["Entity Framework"],
       "ms.topic": "managed-reference",
+      "ms.prod": "ef-core-api",
       "feedback_system": "GitHub",
       "feedback_github_repo": "aspnet/EntityFramework.Docs",
       "feedback_product_url": "https://github.com/aspnet/EntityFrameworkCore/issues/new"

--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -50,8 +50,11 @@
     "globalMetadata": {
       "apiPlatform": "dotnet",
       "author": "dotnet-bot",
+      "ms.author": "divega",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
       "extendBreadcrumb": true,
+      "searchScope": ["Entity Framework"],
+      "ms.topic": "managed-reference",
       "feedback_system": "GitHub",
       "feedback_github_repo": "aspnet/EntityFramework.Docs",
       "feedback_product_url": "https://github.com/aspnet/EntityFrameworkCore/issues/new"


### PR DESCRIPTION
@divega we also need to define which value to use for ms.prod here since it's missing. We could create a new ms.prod and/or ms.technology for the API reference content. Let me know!

Contributes to https://github.com/dotnet/docs/issues/5062