### PR TITLE
Removed duplicate examples from the SqlServerServiceCollectionExtensions

### DIFF
--- a/dotnet/xml/Microsoft.Extensions.DependencyInjection/SqlServerServiceCollectionExtensions.xml
+++ b/dotnet/xml/Microsoft.Extensions.DependencyInjection/SqlServerServiceCollectionExtensions.xml
@@ -82,34 +82,6 @@
                      }
                  </code>
         </example>
-        <example>
-          <code>
-                      public void ConfigureServices(IServiceCollection services)
-                      {
-                          var connectionString = "connection string to database";
-            
-                          services
-                              .AddEntityFrameworkSqlServer()
-                              .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =&gt;
-                                  options.UseSqlServer(connectionString)
-                                         .UseInternalServiceProvider(serviceProvider));
-                      }
-                  </code>
-        </example>
-        <example>
-          <code>
-                       public void ConfigureServices(IServiceCollection services)
-                       {
-                           var connectionString = "connection string to database";
-            
-                           services
-                               .AddEntityFrameworkSqlServer()
-                               .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =&gt;
-                                   options.UseSqlServer(connectionString)
-                                          .UseInternalServiceProvider(serviceProvider));
-                       }
-                   </code>
-        </example>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
We had the same example duplicated a few times, I have now removed this and we are back to 1 example that is no longer duplicated.