### PR TITLE
Correct a reference in DbQuery documentation

### DIFF
--- a/dotnet/xml/Microsoft.EntityFrameworkCore/DbQuery`1.xml
+++ b/dotnet/xml/Microsoft.EntityFrameworkCore/DbQuery`1.xml
@@ -54,7 +54,7 @@
                 </para>
       <para>
         <see cref="T:Microsoft.EntityFrameworkCore.DbQuery`1" /> objects are usually obtained from a <see cref="T:Microsoft.EntityFrameworkCore.DbQuery`1" />
-                    property on a derived <see cref="T:Microsoft.EntityFrameworkCore.DbContext" /> or from the <see cref="M:Microsoft.EntityFrameworkCore.DbContext.Set``1" />
+                    property on a derived <see cref="T:Microsoft.EntityFrameworkCore.DbContext" /> or from the <see cref="M:Microsoft.EntityFrameworkCore.DbContext.Query``1" />
                     method.
                 </para>
     </summary>


### PR DESCRIPTION
Change:
DbQuery<TQuery> objects are usually obtained from a DbQuery<TQuery> property on a derived DbContext or from the Set<TEntity>() method. 
To:
DbQuery<TQuery> objects are usually obtained from a DbQuery<TQuery> property on a derived DbContext or from the Query<TQuery>() method.