### PR TITLE
Fix to #942 - adding note about default command timeout

### DIFF
--- a/dotnet/xml/Microsoft.EntityFrameworkCore/RelationalDatabaseFacadeExtensions.xml
+++ b/dotnet/xml/Microsoft.EntityFrameworkCore/RelationalDatabaseFacadeExtensions.xml
@@ -629,6 +629,9 @@
                     Note that the command timeout is distinct from the connection timeout, which is commonly
                     set on the database connection string.
                 </para>
+          <para>
+                    Default value for the command timeout is determined by the ADO.NET provider.
+                </para>
         </summary>
         <returns> The timeout, in seconds, or null if no timeout has been set. </returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
i.e. that it is determined by provider