### PR TITLE
turn off edit button

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -12,7 +12,7 @@
         "efcore-2.0",
         "efcore-2.1"
       ],
-      "open_to_public_contributors": true,
+      "open_to_public_contributors": false,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",


### PR DESCRIPTION
According to @divega on PR #50, this repo is not supposed to accept external contributions because the content is auto-generated from source. 
So removing the edit button from docs would help with not getting unwanted PRs here.